### PR TITLE
Homepage changes

### DIFF
--- a/src/components/cards/HomePageCard.vue
+++ b/src/components/cards/HomePageCard.vue
@@ -4,6 +4,7 @@
             height="300"
             :src="asset"
             :alt="asset"
+            :contain="contain"
         />
 
         <v-card-title class="feature-title">{{ title }}</v-card-title>
@@ -23,7 +24,8 @@ export default defineComponent({
     props: {
         title: String,
         asset: String,
-        hover: Boolean
+        hover: Boolean,
+        contain: Boolean
     }
 });
 </script>

--- a/src/components/cards/ReleaseOverviewCard.vue
+++ b/src/components/cards/ReleaseOverviewCard.vue
@@ -18,38 +18,25 @@
 
                         <v-spacer />
 
-                        <v-chip v-if="item.version"
-                            class="ma-2 mb-0 justify-left"
+                        <v-chip v-if="recentDate(item.date, 250)"
+                            class="recent-release my-2 mb-0 px-2 justify-left"
                             small
                             label
-                            color="primary"
+                            color="green"
                         >
-                            {{ item.version }}
+                            <v-icon class="white--text me-2">
+                                mdi-flag
+                            </v-icon>
                         </v-chip>
 
-                        <Tooltip :message="formatDateFull(item.date)">
-                            <v-chip v-if="recentDate(item.date, 120)"
-                                class="recent-release my-2 mb-0 px-2 justify-left"
+                        <Tooltip v-if="item.version" :message="formatDateFull(item.date)">
+                            <v-chip
+                                class="ma-2 mb-0 justify-left"
                                 small
                                 label
-                                color="green"
+                                color="primary"
                             >
-                                <v-icon class="white--text me-2">
-                                    mdi-flag
-                                </v-icon>
-                                <span>
-                                    {{ formatDate(item.date) }}
-                                </span>
-                            </v-chip>
-
-                            <v-chip v-else-if="item.version"
-                                class="my-2 mb-0 px-2 justify-left"
-                                small
-                                label
-                            >
-                                <span>
-                                    {{ formatDate(item.date) }}
-                                </span>
+                                {{ item.version }}
                             </v-chip>
                         </Tooltip>
 
@@ -97,15 +84,6 @@ const months = [
     "December"
 ];
 
-const leadingZero = (number: number) => {
-    return number < 10 ? `0${number}` : number;
-}
-
-const formatDate = (dateString: string) => {
-    const date = new Date(dateString);
-    return `${leadingZero(date.getDate())}-${leadingZero(date.getMonth() + 1)}-${date.getFullYear()}`;
-}
-
 const formatDateFull = (dateString: string) => {
     const date = new Date(dateString);
     return `${date.getDate()} ${months[date.getMonth()]} ${date.getFullYear()}`;
@@ -134,11 +112,8 @@ const recentDate = (dateString: string, maxDays: number) => {
 }
 
 .recent-release:after {
-    content: "New release" !important;
+    content: "New" !important;
+    font-weight: bold;
     color: white;
-}
-
-.recent-release:hover:after {
-    content: none !important;
 }
 </style>

--- a/src/components/cards/ReleaseOverviewCard.vue
+++ b/src/components/cards/ReleaseOverviewCard.vue
@@ -27,31 +27,31 @@
                             {{ item.version }}
                         </v-chip>
 
-                        <v-chip v-if="recentDate(item.date, 120)"
-                            class="recent-release my-2 mb-0 px-2 justify-left"
-                            small
-                            label
-                            color="green"
-                        >
-                            <v-icon class="white--text me-2">
-                                mdi-flag
-                            </v-icon>
-                            <span>
-                                {{ formatDate(item.date) }}
-                            </span>
-                        </v-chip>
+                        <Tooltip :message="formatDateFull(item.date)">
+                            <v-chip v-if="recentDate(item.date, 120)"
+                                class="recent-release my-2 mb-0 px-2 justify-left"
+                                small
+                                label
+                                color="green"
+                            >
+                                <v-icon class="white--text me-2">
+                                    mdi-flag
+                                </v-icon>
+                                <span>
+                                    {{ formatDate(item.date) }}
+                                </span>
+                            </v-chip>
 
-                        <v-chip v-else-if="item.version"
-                            class="my-2 mb-0 px-2 justify-left"
-                            small
-                            label
-                        >
-                            <span>
-                                {{ formatDate(item.date) }}
-                            </span>
-                        </v-chip>
-
-                        <v-spacer />
+                            <v-chip v-else-if="item.version"
+                                class="my-2 mb-0 px-2 justify-left"
+                                small
+                                label
+                            >
+                                <span>
+                                    {{ formatDate(item.date) }}
+                                </span>
+                            </v-chip>
+                        </Tooltip>
 
                         <v-list-item-icon>
                             <v-icon>mdi-chevron-right</v-icon>
@@ -64,6 +64,7 @@
 </template>
 
 <script setup lang="ts">
+import { Tooltip } from "unipept-web-components";
 import { defineProps } from "vue";
 import HeaderBodyCard from "./HeaderBodyCard.vue";
 
@@ -81,9 +82,33 @@ export interface Props {
 
 const { services } = defineProps<Props>();
 
+const months = [
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December"
+];
+
+const leadingZero = (number: number) => {
+    return number < 10 ? `0${number}` : number;
+}
+
 const formatDate = (dateString: string) => {
     const date = new Date(dateString);
-    return `${date.getDate()}-${date.getMonth() + 1}-${date.getFullYear()}`;
+    return `${leadingZero(date.getDate())}-${leadingZero(date.getMonth() + 1)}-${date.getFullYear()}`;
+}
+
+const formatDateFull = (dateString: string) => {
+    const date = new Date(dateString);
+    return `${date.getDate()} ${months[date.getMonth()]} ${date.getFullYear()}`;
 }
 
 const recentDate = (dateString: string, maxDays: number) => {

--- a/src/components/cards/ReleaseOverviewCard.vue
+++ b/src/components/cards/ReleaseOverviewCard.vue
@@ -18,7 +18,7 @@
 
                         <v-spacer />
 
-                        <v-chip v-if="recentDate(item.date, 250)"
+                        <v-chip v-if="recentDate(item.date, 90)"
                             class="recent-release my-2 mb-0 px-2 justify-left"
                             small
                             label

--- a/src/components/cards/ReleaseOverviewCard.vue
+++ b/src/components/cards/ReleaseOverviewCard.vue
@@ -69,24 +69,9 @@ export interface Props {
 
 const { services } = defineProps<Props>();
 
-const months = [
-    "January",
-    "February",
-    "March",
-    "April",
-    "May",
-    "June",
-    "July",
-    "August",
-    "September",
-    "October",
-    "November",
-    "December"
-];
-
 const formatDateFull = (dateString: string) => {
     const date = new Date(dateString);
-    return `${date.getDate()} ${months[date.getMonth()]} ${date.getFullYear()}`;
+    return `${date.getDate()} ${date.toLocaleString('en', { month: 'long' })} ${date.getFullYear()}`;
 }
 
 const recentDate = (dateString: string, maxDays: number) => {

--- a/src/components/cards/ReleaseOverviewCard.vue
+++ b/src/components/cards/ReleaseOverviewCard.vue
@@ -12,7 +12,7 @@
                             <v-icon>{{ item.icon }}</v-icon>
                         </v-list-item-icon>
 
-                        <v-list-item-content v-if="$vuetify.breakpoint.smAndUp" class="fixed-flex-size">
+                        <v-list-item-content class="fixed-flex-size">
                             <v-list-item-title>{{ item.name }}</v-list-item-title>
                         </v-list-item-content>
 

--- a/src/components/pages/HomePage.vue
+++ b/src/components/pages/HomePage.vue
@@ -70,7 +70,7 @@
                 <router-link to="/apidocs">
                     <v-hover>
                         <template v-slot:default="{ hover }">
-                            <HomePageCard :hover="hover" title="API Documentation" :asset="require('@/assets/homepage/home-feature-api.svg')">
+                            <HomePageCard :hover="hover" title="API Documentation" :asset="require('@/assets/homepage/home-feature-api.svg')" contain>
                                 Unipept offers most of its peptide analysis features as a <span class='font-weight-bold'>web service</span>. This enables 
                                 the integration of Unipept functionality into other applications and the creation of batch processing scripts. These 
                                 <span class='font-weight-bold'>documentation pages</span> describe the available features of the API, how to access them and 
@@ -86,7 +86,7 @@
                 <router-link to="/clidocs">
                     <v-hover>
                         <template v-slot:default="{ hover }">
-                            <HomePageCard :hover="hover" title="CLI Documentation" :asset="require('@/assets/homepage/home-feature-cli.svg')">
+                            <HomePageCard :hover="hover" title="CLI Documentation" :asset="require('@/assets/homepage/home-feature-cli.svg')" contain>
                                 The Unipept <span class='font-weight-bold'>command line interface</span> (CLI) is a wrapper around the Unipept API that 
                                 offers an easy way to <span class='font-weight-bold'>integrate Unipept</span> functionality into your data processing 
                                 <span class='font-weight-bold'>pipelines and scripts</span>. These pages cover installation and usage instructions, an 
@@ -102,7 +102,7 @@
                 <router-link to="/umgap">
                     <v-hover>
                         <template v-slot:default="{ hover }">
-                            <HomePageCard :hover="hover" title="UMGAP" :asset="require('@/assets/homepage/home-feature-umgap.svg')">
+                            <HomePageCard :hover="hover" title="UMGAP" :asset="require('@/assets/homepage/home-feature-umgap.svg')" contain>
                                 Use the Unipept MetaGenomics Analysis Pipeline to assign taxonomic labels to your <span class='font-weight-bold'>shotgun 
                                 metagenomics reads</span>. The results are available as taxonomic frequency tables and interactive visualizations. UMGAP 
                                 is a collection of CLI tools that can be combined to identify shotgun metagenomics reads.


### PR DESCRIPTION
Added changes to the homepage:
- [x] Latest versions:
- [x] Latest versions: Version labels are not right aligned
<img width="389" alt="Screenshot 2023-01-24 at 12 54 39" src="https://user-images.githubusercontent.com/34175340/214285228-fe0b2e9d-6f90-4907-8238-0c56bb2f6fd3.png">

- [x] Latest versions: Date format is not "international", maybe write it in full to avoid confusion? Maybe move it to a tooltip?
Added leading zero's to the date. I kept the format, but display the date in a separate tooltip.
<img width="389" alt="Screenshot 2023-01-24 at 12 56 39" src="https://user-images.githubusercontent.com/34175340/214285595-cbfca2bc-f08c-4e13-b857-20f4e2c3c9f1.png">

- [x] Fix icon size on the homepage. Icons are to stretched.
<img width="476" alt="Screenshot 2023-01-24 at 13 02 40" src="https://user-images.githubusercontent.com/34175340/214286883-115580c9-db2f-43fa-8a48-5c1bbd652636.png">

Currently we show a green 'new release' tag in case of new releases. Maybe there is a better way to visualise this. @bmesuere @pverscha 
<img width="550" alt="Screenshot 2023-01-24 at 13 05 39" src="https://user-images.githubusercontent.com/34175340/214287765-95350184-500c-486a-bc86-649e2e900db5.png">