### PR TITLE
Tpa changes

### DIFF
--- a/src/components/cards/analysis/single/TrypticPeptideAnalysisSearchCard.vue
+++ b/src/components/cards/analysis/single/TrypticPeptideAnalysisSearchCard.vue
@@ -22,7 +22,8 @@
                     <v-row>
                         <v-col>
                             <p class="mb-0">
-                                Search for a single tryptic peptide (e.g. AALTER) by entering the sequence below.
+                                Search for a single tryptic peptide (e.g. AALTER) by entering the sequence below. Note that your input should only consist of <b>5</b> to <b>50</b> amino acids. 
+                                Lowercase letters are allowed, but will be converted to their uppercase counterpart.
                             </p>
                         </v-col>
                     </v-row>

--- a/src/components/cards/analysis/single/TrypticPeptideAnalysisSearchCard.vue
+++ b/src/components/cards/analysis/single/TrypticPeptideAnalysisSearchCard.vue
@@ -13,12 +13,19 @@
             <router-link
                 :to="{
                     name: 'tpaResult',
-                    params: { sequence: sequence },
+                    params: { sequence: sequence.toUpperCase() },
                     query: { equate: equate_il }
                 }"
                 v-slot="{ navigate }"
             >
                 <v-form v-model="validForm" @submit="navigate">
+                    <v-row>
+                        <v-col>
+                            <p class="mb-0">
+                                Search for a single tryptic peptide (e.g. AALTER) by entering the sequence below.
+                            </p>
+                        </v-col>
+                    </v-row>
                     <v-row>
                         <v-col class="pb-0" cols=12>
                             <v-text-field

--- a/src/components/cards/analysis/single/TrypticPeptideAnalysisSearchCard.vue
+++ b/src/components/cards/analysis/single/TrypticPeptideAnalysisSearchCard.vue
@@ -32,11 +32,12 @@
 
                     <v-row>
                         <v-col class="py-0" cols=12 md=6>
-                            <v-switch
-                                v-model="equate_il"
-                                label="Equate I and L?"
-                                inset
-                            ></v-switch>
+                            <Tooltip message="Equate isoleucine (I) and leucine (L) when matching peptides to UniProt entries.">
+                                <v-checkbox
+                                    v-model="equate_il"
+                                    label="Equate I and L?"
+                                ></v-checkbox>
+                            </Tooltip>
                         </v-col>
 
                         <v-col class="d-flex" cols=12 md=6>
@@ -57,6 +58,7 @@
 </template>
 
 <script setup lang="ts">
+import { Tooltip } from 'unipept-web-components';
 import { ref } from 'vue';
 
 const validForm = ref(false);

--- a/src/components/cards/analysis/single/TrypticPeptideAnalysisSearchCard.vue
+++ b/src/components/cards/analysis/single/TrypticPeptideAnalysisSearchCard.vue
@@ -22,7 +22,7 @@
                     <v-row>
                         <v-col>
                             <p class="mb-0">
-                                Search for a single tryptic peptide (e.g. <ResourceLink to="/tpa/AALTER?equate=true" router>AALTER</ResourceLink>) by entering the sequence below. Note that your input should only consist of <b>5</b> to <b>50</b> amino acids. 
+                                Search for a single tryptic peptide (e.g. <ResourceLink to="/tpa/MDGTEYIIVK?equate=true" router>MDGTEYIIVK</ResourceLink>) by entering the sequence below. Note that your input should only consist of <b>5</b> to <b>50</b> amino acids. 
                                 Lowercase letters are allowed, but will be converted to their uppercase counterpart.
                             </p>
                         </v-col>

--- a/src/components/cards/analysis/single/TrypticPeptideAnalysisSearchCard.vue
+++ b/src/components/cards/analysis/single/TrypticPeptideAnalysisSearchCard.vue
@@ -18,7 +18,7 @@
                 }"
                 v-slot="{ navigate }"
             >
-                <v-form v-model="validForm" @submit="navigate">
+                <v-form ref="form" v-model="validForm" @submit="navigate">
                     <v-row>
                         <v-col>
                             <p class="mb-0">
@@ -33,6 +33,7 @@
                                 v-model.trim="sequence"
                                 label="Sequence"
                                 :rules="sequenceRules"
+                                autofocus
                             ></v-text-field>
                         </v-col>
                     </v-row>
@@ -71,6 +72,8 @@ import { ref } from 'vue';
 const validForm = ref(false);
 const sequence = ref("");
 const equateIl = ref(true);
+
+const form = ref(null);
 
 const sequenceRules = [
     (value: string) => /^[A-Z]+$/.test(value.toUpperCase()) || "Peptide can only consist of letters",

--- a/src/components/cards/analysis/single/TrypticPeptideAnalysisSearchCard.vue
+++ b/src/components/cards/analysis/single/TrypticPeptideAnalysisSearchCard.vue
@@ -14,7 +14,7 @@
                 :to="{
                     name: 'tpaResult',
                     params: { sequence: sequence.toUpperCase() },
-                    query: { equate: equate_il }
+                    query: { equate: equateIl }
                 }"
                 v-slot="{ navigate }"
             >
@@ -41,7 +41,7 @@
                         <v-col class="py-0" cols=12 md=6>
                             <Tooltip message="Equate isoleucine (I) and leucine (L) when matching peptides to UniProt entries.">
                                 <v-checkbox
-                                    v-model="equate_il"
+                                    v-model="equateIl"
                                     label="Equate I and L?"
                                 ></v-checkbox>
                             </Tooltip>
@@ -70,7 +70,7 @@ import { ref } from 'vue';
 
 const validForm = ref(false);
 const sequence = ref("");
-const equate_il = ref(true);
+const equateIl = ref(true);
 
 const sequenceRules = [
     (value: string) => /^[A-Z]+$/.test(value.toUpperCase()) || "Peptide can only consist of letters",

--- a/src/components/cards/analysis/single/TrypticPeptideAnalysisSearchCard.vue
+++ b/src/components/cards/analysis/single/TrypticPeptideAnalysisSearchCard.vue
@@ -22,7 +22,7 @@
                     <v-row>
                         <v-col>
                             <p class="mb-0">
-                                Search for a single tryptic peptide (e.g. AALTER) by entering the sequence below. Note that your input should only consist of <b>5</b> to <b>50</b> amino acids. 
+                                Search for a single tryptic peptide (e.g. <ResourceLink to="/tpa/AALTER?equate=true" router>AALTER</ResourceLink>) by entering the sequence below. Note that your input should only consist of <b>5</b> to <b>50</b> amino acids. 
                                 Lowercase letters are allowed, but will be converted to their uppercase counterpart.
                             </p>
                         </v-col>
@@ -67,6 +67,7 @@
 </template>
 
 <script setup lang="ts">
+import ResourceLink from '@/components/highlights/ResourceLink.vue';
 import { Tooltip } from 'unipept-web-components';
 import { ref } from 'vue';
 

--- a/src/components/pages/analysis/TrypticPeptideAnalysisResultPage.vue
+++ b/src/components/pages/analysis/TrypticPeptideAnalysisResultPage.vue
@@ -9,10 +9,5 @@
 <script setup lang="ts">
 import SinglePeptideAnalysisyWrapper from "../../wrappers/SinglePeptideAnalysisWrapper.vue";
 
-const equate = (equate: string | (string | null)[]): boolean => {
-    if(equate === "true") {
-        return true;
-    }
-    return false;
-}
+const equate = (equate: string | (string | null)[]): boolean => { return equate ? true : false };
 </script>

--- a/src/components/wrappers/SinglePeptideAnalysisWrapper.vue
+++ b/src/components/wrappers/SinglePeptideAnalysisWrapper.vue
@@ -39,16 +39,19 @@ analysisStore.analyse(peptide, equateIl);
 
 const onGoClicked = (router: VueRouter) => {
     currentTab.value = 3;
+    // https://github.com/vuejs/vue-router/issues/2881#issuecomment-520554378
     router.push({ path: '#Analysis' }).catch(() => {});
 }
 
 const onEcClicked = (router: VueRouter) => {
     currentTab.value = 4;
+    // https://github.com/vuejs/vue-router/issues/2881#issuecomment-520554378
     router.push({ path: '#Analysis' }).catch(() => {});
 }
 
 const onInterproClicked = (router: VueRouter) => {
     currentTab.value = 5;
+    // https://github.com/vuejs/vue-router/issues/2881#issuecomment-520554378
     router.push({ path: '#Analysis' }).catch(() => {});
 }
 </script>

--- a/src/components/wrappers/SinglePeptideAnalysisWrapper.vue
+++ b/src/components/wrappers/SinglePeptideAnalysisWrapper.vue
@@ -1,26 +1,54 @@
 <template>
     <div>
-        <single-peptide-summary class="my-5" :assay="analysisStore.assay" :toggleFullscreen="toggle" />
-        <single-peptide-analysis :assay="analysisStore.assay" />
+        <single-peptide-summary 
+            class="my-5" 
+            :assay="analysisStore.assay" 
+            :toggleFullscreen="toggle" 
+            goLink
+            ecLink
+            interproLink
+            @goLinkClicked="() => onGoClicked($router)"
+            @ecLinkClicked="() => onEcClicked($router)"
+            @interproLinkClicked="() => onInterproClicked($router)"
+        />
+        <single-peptide-analysis id="Analysis" :assay="analysisStore.assay" :tab="currentTab" @tabUpdate="currentTab = $event" />
     </div>
 </template>
 
 <script setup lang="ts">
-import { defineProps } from 'vue';
+import { defineProps, ref } from 'vue';
 import { SinglePeptideSummary, SinglePeptideAnalysis } from 'unipept-web-components';
 import { useSingleAnalysis } from '@/stores';
 import { useFullscreen } from '@vueuse/core';
+import VueRouter from 'vue-router';
 
 export interface Props {
     peptide: string
     equateIl: boolean
 }
 
-const { toggle } = useFullscreen()
-
 const { peptide, equateIl } = defineProps<Props>();
 
 const analysisStore = useSingleAnalysis();
 
+const { toggle } = useFullscreen();
+
+const currentTab = ref<number>(0);
+
 analysisStore.analyse(peptide, equateIl);
+
+const onGoClicked = (router: VueRouter) => {
+    currentTab.value = 3;
+    router.push({ path: '#Analysis' }).catch(() => {});
+}
+
+const onEcClicked = (router: VueRouter) => {
+    currentTab.value = 4;
+    router.push({ path: '#Analysis' }).catch(() => {});
+}
+
+const onInterproClicked = (router: VueRouter) => {
+    currentTab.value = 5;
+    router.push({ path: '#Analysis' }).catch(() => {});
+}
 </script>


### PR DESCRIPTION
**IMPORTANT NOTE: The changes in this PR are linked to some changes in the unipept-web-components repository**

- [x] Search page can use a little help text (and an example peptide?)
- [x] Is a toggle the right UI here? According to the spec, a toggle should be used for a setting that gets updated immediately. It seems that this should be a checkbox since it's a form.
<img width="727" alt="Screenshot 2023-01-24 at 14 53 03" src="https://user-images.githubusercontent.com/34175340/214312759-e1b13215-6e51-45d3-af10-3fba76c2d192.png">

- [x] The equate I and L toggle has not tooltip (see MPA)
<img width="727" alt="Screenshot 2023-01-24 at 14 54 27" src="https://user-images.githubusercontent.com/34175340/214312949-1793db65-7202-4f78-ae0c-07abfb79ad4e.png">

- [x] Search button is disabled when loading the page (which is ok) but because the form is minimal, people might not realize "sequence" is an input field. A little help text (see first point here) or enabling the button but showing an error on empty search might be better.
<img width="727" alt="Screenshot 2023-01-24 at 14 52 52" src="https://user-images.githubusercontent.com/34175340/214313614-2426bf66-542e-4f8d-a5f2-dea08240445f.png">

For some reason I wasn't able to add an extra validation on submit. The router / Vuetify combination gave some weird webpack errors. Instead I went for a combination between a small introduction and autofocus on the input. Errors are present in case of bad input.

- [x] In the function list on the top of the page, maybe "go term", "ec number" etc can be links to the respective tabs below?
<img width="1145" alt="Screenshot 2023-01-24 at 16 47 18" src="https://user-images.githubusercontent.com/34175340/214340554-1b25d7e6-26cd-449f-8d2b-6aea9aecaa49.png">

**Bug fixes**

- [x]  Apply text transform upper to the input field. Peptide sequences should always be shown in uppercase
- [x] I=L was enabled on the form, but on the results page "Equate I/L is disabled" is shown
- [x] When the LCA is root, the link after "The lowest common ancestor is" includes an additional space at the end. The link for root also doesn't work. The links in common lineage also include spaces inside the link tag
- [x] If I click the cog icon, some sort of percentage filter appears. However, there is no explanation, the current value isn't shown (only in small when you drag the slider), there is no "ok" button and it doesn't seem to work.

<img width="1145" alt="Screenshot 2023-01-24 at 16 53 12" src="https://user-images.githubusercontent.com/34175340/214341957-9973832c-df6b-4b3d-b644-b3cb07c81d74.png">

Tryptic peptide analysis supports no filtering. I removed the cog-icon.