### PR TITLE
Documentation changes

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -113,6 +113,10 @@ QueueManager.initializeQueue(4);
     }
 }
 
+body {
+    font-size: 16px;
+}
+
 .homepage-title {
     color: white !important;
     text-decoration: none;
@@ -136,22 +140,17 @@ QueueManager.initializeQueue(4);
     color: #333333 !important;
 }
 
-li {
-    line-height: 1.8;
-}
-
-.v-card__text p {
-    font-size: 100%;
-}
-
-.v-card__content p {
-    font-size: 100%;
-}
-
 p {
     color: #333333 !important;
-    font-size: 90%;
     margin-bottom: 8px !important;
+}
+
+li {
+    font-size: 16px;
+}
+
+td {
+    font-size: 16px !important;
 }
 
 .v-card h3 {

--- a/src/components/cards/ExampleCard.vue
+++ b/src/components/cards/ExampleCard.vue
@@ -12,7 +12,9 @@
                 </Boxed>
 
                 <Initialism><b>get</b></Initialism>
-                <pre class="request"><slot name="get"></slot></pre>
+                <Boxed>
+                    <slot name="get"></slot>
+                </Boxed>
             </v-card-text>
 
             <v-divider />
@@ -40,20 +42,8 @@ defineProps<Props>();
 </script>
 
 <style scoped>
-.request {
-    display: block;
-    border: 1px solid #cccccc;
-    border-radius: 2px;
-    padding: 8px;
-    background-color: #f5f5f5;
-    overflow: auto;
-    line-height: 0;
-    padding: 20px 10px;
-    margin-bottom: 12px;
-}
-
-.sentinel {
-    color: #c65d09;
+h4 {
+    font-size: 16px;
 }
 
 .limited {

--- a/src/components/highlights/Boxed.vue
+++ b/src/components/highlights/Boxed.vue
@@ -13,5 +13,6 @@
     line-height: 1.5;
     margin-bottom: 12px;
     max-height: 350px;
+    font-size: 90%;
 }
 </style>

--- a/src/components/highlights/Boxed.vue
+++ b/src/components/highlights/Boxed.vue
@@ -1,9 +1,9 @@
 <template>
-    <pre id="boxed"><slot></slot></pre>
+    <pre class="boxed"><slot></slot></pre>
 </template>
 
 <style scoped>
-#boxed {
+.boxed {
     display: block;
     border: 1px solid #cccccc;
     border-radius: 2px;

--- a/src/components/highlights/InlineCode.vue
+++ b/src/components/highlights/InlineCode.vue
@@ -10,5 +10,6 @@ code {
     padding: 2px 4px !important;
     background-color: #f9f2f4 !important;
     border-radius: 2px !important;
+    font-size: 90%;
 };
 </style>

--- a/src/components/highlights/Json.vue
+++ b/src/components/highlights/Json.vue
@@ -1,5 +1,5 @@
 <template>
-    <pre v-html="jsonParser.parseAndHighlight(object)"></pre>
+    <pre class="fs" v-html="jsonParser.parseAndHighlight(object)"></pre>
 </template>
 
 <script setup lang="ts">
@@ -16,8 +16,7 @@ const jsonParser = new JsonParser();
 </script>
 
 <style scoped>
-span {
-    text-transform: uppercase;
+.fs {
     font-size: 90%;
 };
 </style>

--- a/src/components/pages/apidocs/OverviewPage.vue
+++ b/src/components/pages/apidocs/OverviewPage.vue
@@ -29,7 +29,7 @@
                     </thead>
                     <tbody>
                         <router-link v-for="item in functions" class="clickable" :key="item.resource" :to="item.link" tag="tr">
-                            <td>
+                            <td style="white-space: nowrap;">
                                 <b>{{ item.resource }}</b>
                             </td>
                             <td class="py-3">

--- a/src/components/pages/apidocs/Pept2EcPage.vue
+++ b/src/components/pages/apidocs/Pept2EcPage.vue
@@ -16,7 +16,7 @@
         <HeaderBodyCard id="request" title="Request">
             <p>
                 The pept2ec method can be used by doing a <Initialism>HTTP POST</Initialism>-request (preferred) or <Initialism>GET</Initialism>-request to 
-                <Code>http://api.unipept.ugent.be/api/v1/pept2ec</Code>. <RLink to="#parameters" router>Parameters</RLink> can be included in the request body 
+                <Code>https://api.unipept.ugent.be/api/v1/pept2ec</Code>. <RLink to="#parameters" router>Parameters</RLink> can be included in the request body 
                 (<Initialism>POST</Initialism>) or in the query string (<Initialism>GET</Initialism>). The only required parameter is <Code>input[]</Code>, which 
                 takes one or more tryptic peptides.
             </p>
@@ -151,7 +151,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/pept2ec -d 'input[]=AIPQLEVARPADAYETAEAYR'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/pept2ec.json?input[]=AIPQLEVARPADAYETAEAYR
+                https://api.unipept.ugent.be/api/v1/pept2ec.json?input[]=AIPQLEVARPADAYETAEAYR
             </template>
         </ExampleCard>
 
@@ -170,7 +170,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/pept2ec -d 'input[]=AIPQLEVARPADAYETAEAYR' -d 'input[]=APVLSDSSCK'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/pept2ec.json?input[]=AIPQLEVARPADAYETAEAYR&input[]=APVLSDSSCK
+                https://api.unipept.ugent.be/api/v1/pept2ec.json?input[]=AIPQLEVARPADAYETAEAYR&input[]=APVLSDSSCK
             </template>
         </ExampleCard>
 
@@ -188,7 +188,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/pept2ec -d 'input[]=APVISDSSCK' -d 'equate_il=true'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/pept2ec.json?input[]=APVISDSSCK&equate_il=true
+                https://api.unipept.ugent.be/api/v1/pept2ec.json?input[]=APVISDSSCK&equate_il=true
             </template>
         </ExampleCard>
 
@@ -206,7 +206,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/pept2ec -d 'input[]=AIPQLEVARPADAYETAEAYR' -d 'extra=true'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/pept2ec.json?input[]=AIPQLEVARPADAYETAEAYR&extra=true
+                https://api.unipept.ugent.be/api/v1/pept2ec.json?input[]=AIPQLEVARPADAYETAEAYR&extra=true
             </template>
         </ExampleCard>
 

--- a/src/components/pages/apidocs/Pept2FunctPage.vue
+++ b/src/components/pages/apidocs/Pept2FunctPage.vue
@@ -19,7 +19,7 @@
         <HeaderBodyCard id="request" title="Request">
             <p>
                 The pept2funct method can be used by doing a <Initialism>HTTP POST</Initialism>-request (preferred) or <Initialism>GET</Initialism>-request to 
-                <Code>http://api.unipept.ugent.be/api/v1/pept2funct</Code>. <RLink to="#parameters" router>Parameters</RLink> can be included in the request body 
+                <Code>https://api.unipept.ugent.be/api/v1/pept2funct</Code>. <RLink to="#parameters" router>Parameters</RLink> can be included in the request body 
                 (<Initialism>POST</Initialism>) or in the query string (<Initialism>GET</Initialism>). The only required parameter is <Code>input[]</Code>, which 
                 takes one or more tryptic peptides.
             </p>
@@ -208,7 +208,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/pept2funct -d 'input[]=AIPQLEVARPADAYETAEAYR'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/pept2funct.json?input[]=AIPQLEVARPADAYETAEAYR
+                https://api.unipept.ugent.be/api/v1/pept2funct.json?input[]=AIPQLEVARPADAYETAEAYR
             </template>
         </ExampleCard>
 
@@ -227,7 +227,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/pept2funct -d 'input[]=AIPQLEVARPADAYETAEAYR' -d 'input[]=APVLSDSSCK'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/pept2funct.json?input[]=AIPQLEVARPADAYETAEAYR&input[]=APVLSDSSCK
+                https://api.unipept.ugent.be/api/v1/pept2funct.json?input[]=AIPQLEVARPADAYETAEAYR&input[]=APVLSDSSCK
             </template>
         </ExampleCard>
 
@@ -245,7 +245,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/pept2funct -d 'input[]=APVISDSSCK' -d 'equate_il=true'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/pept2funct.json?input[]=APVISDSSCK&equate_il=true
+                https://api.unipept.ugent.be/api/v1/pept2funct.json?input[]=APVISDSSCK&equate_il=true
             </template>
         </ExampleCard>
 
@@ -264,7 +264,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/pept2funct -d 'input[]=AIPQLEVARPADAYETAEAYR' -d 'extra=true'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/pept2funct.json?input[]=AIPQLEVARPADAYETAEAYR&extra=true
+                https://api.unipept.ugent.be/api/v1/pept2funct.json?input[]=AIPQLEVARPADAYETAEAYR&extra=true
             </template>
         </ExampleCard>
 
@@ -282,7 +282,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/pept2funct -d 'input[]=APVLSDSSCK' -d 'domains=true'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/pept2funct.json?input[]=APVLSDSSCK&domains=true
+                https://api.unipept.ugent.be/api/v1/pept2funct.json?input[]=APVLSDSSCK&domains=true
             </template>
         </ExampleCard>
 

--- a/src/components/pages/apidocs/Pept2GoPage.vue
+++ b/src/components/pages/apidocs/Pept2GoPage.vue
@@ -16,7 +16,7 @@
         <HeaderBodyCard id="request" title="Request">
             <p>
                 The pept2go method can be used by doing a <Initialism>HTTP POST</Initialism>-request (preferred) or <Initialism>GET</Initialism>-request to 
-                <Code>http://api.unipept.ugent.be/api/v1/pept2go</Code>. <RLink to="#parameters" router>Parameters</RLink> can be included in the request body 
+                <Code>https://api.unipept.ugent.be/api/v1/pept2go</Code>. <RLink to="#parameters" router>Parameters</RLink> can be included in the request body 
                 (<Initialism>POST</Initialism>) or in the query string (<Initialism>GET</Initialism>). The only required parameter is <Code>input[]</Code>, which 
                 takes one or more tryptic peptides.
             </p>
@@ -172,7 +172,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/pept2go -d 'input[]=AIPQLEVARPADAYETAEAYR'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/pept2go.json?input[]=AIPQLEVARPADAYETAEAYR
+                https://api.unipept.ugent.be/api/v1/pept2go.json?input[]=AIPQLEVARPADAYETAEAYR
             </template>
         </ExampleCard>
 
@@ -191,7 +191,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/pept2go -d 'input[]=AIPQLEVARPADAYETAEAYR' -d 'input[]=APVLSDSSCK'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/pept2go.json?input[]=AIPQLEVARPADAYETAEAYR&input[]=APVLSDSSCK
+                https://api.unipept.ugent.be/api/v1/pept2go.json?input[]=AIPQLEVARPADAYETAEAYR&input[]=APVLSDSSCK
             </template>
         </ExampleCard>
 
@@ -209,7 +209,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/pept2go -d 'input[]=APVISDSSCK' -d 'equate_il=true'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/pept2go.json?input[]=APVISDSSCK&equate_il=true
+                https://api.unipept.ugent.be/api/v1/pept2go.json?input[]=APVISDSSCK&equate_il=true
             </template>
         </ExampleCard>
 
@@ -227,7 +227,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/pept2go -d 'input[]=AIPQLEVARPADAYETAEAYR' -d 'extra=true'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/pept2go.json?input[]=AIPQLEVARPADAYETAEAYR&extra=true
+                https://api.unipept.ugent.be/api/v1/pept2go.json?input[]=AIPQLEVARPADAYETAEAYR&extra=true
             </template>
         </ExampleCard>
 
@@ -244,7 +244,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/pept2go -d 'input[]=APVLSDSSCK' -d 'domains=true'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/pept2go.json?input[]=APVLSDSSCK&domains=true
+                https://api.unipept.ugent.be/api/v1/pept2go.json?input[]=APVLSDSSCK&domains=true
             </template>
         </ExampleCard>
 

--- a/src/components/pages/apidocs/Pept2InterproPage.vue
+++ b/src/components/pages/apidocs/Pept2InterproPage.vue
@@ -16,7 +16,7 @@
         <HeaderBodyCard id="request" title="Request">
             <p>
                 The pept2interpro method can be used by doing a <Initialism>HTTP POST</Initialism>-request (preferred) or <Initialism>GET</Initialism>-request to 
-                <Code>http://api.unipept.ugent.be/api/v1/pept2interpro</Code>. <RLink to="#parameters" router>Parameters</RLink> can be included in the request body 
+                <Code>https://api.unipept.ugent.be/api/v1/pept2interpro</Code>. <RLink to="#parameters" router>Parameters</RLink> can be included in the request body 
                 (<Initialism>POST</Initialism>) or in the query string (<Initialism>GET</Initialism>). The only required parameter is <Code>input[]</Code>, which 
                 takes one or more tryptic peptides.
             </p>
@@ -172,7 +172,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/pept2interpro -d 'input[]=AIPQLEVARPADAYETAEAYR'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/pept2interpro.json?input[]=AIPQLEVARPADAYETAEAYR
+                https://api.unipept.ugent.be/api/v1/pept2interpro.json?input[]=AIPQLEVARPADAYETAEAYR
             </template>
         </ExampleCard>
 
@@ -191,7 +191,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/pept2interpro -d 'input[]=AIPQLEVARPADAYETAEAYR' -d 'input[]=APVLSDSSCK'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/pept2interpro.json?input[]=AIPQLEVARPADAYETAEAYR&input[]=APVLSDSSCK
+                https://api.unipept.ugent.be/api/v1/pept2interpro.json?input[]=AIPQLEVARPADAYETAEAYR&input[]=APVLSDSSCK
             </template>
         </ExampleCard>
 
@@ -209,7 +209,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/pept2interpro -d 'input[]=APVISDSSCK' -d 'equate_il=true'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/pept2interpro.json?input[]=APVISDSSCK&equate_il=true
+                https://api.unipept.ugent.be/api/v1/pept2interpro.json?input[]=APVISDSSCK&equate_il=true
             </template>
         </ExampleCard>
 
@@ -227,7 +227,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/pept2interpro -d 'input[]=AIPQLEVARPADAYETAEAYR' -d 'extra=true'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/pept2interpro.json?input[]=AIPQLEVARPADAYETAEAYR&extra=true
+                https://api.unipept.ugent.be/api/v1/pept2interpro.json?input[]=AIPQLEVARPADAYETAEAYR&extra=true
             </template>
         </ExampleCard>
 
@@ -244,7 +244,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/pept2interpro -d 'input[]=APVLSDSSCK' -d 'domains=true'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/pept2interpro.json?input[]=APVLSDSSCK&domains=true
+                https://api.unipept.ugent.be/api/v1/pept2interpro.json?input[]=APVLSDSSCK&domains=true
             </template>
         </ExampleCard>
 

--- a/src/components/pages/apidocs/Pept2LcaPage.vue
+++ b/src/components/pages/apidocs/Pept2LcaPage.vue
@@ -16,7 +16,7 @@
         <HeaderBodyCard id="request" title="Request">
             <p>
                 The pept2lca method can be used by doing a <Initialism>HTTP POST</Initialism>-request (preferred) or <Initialism>GET</Initialism>-request to 
-                <Code>http://api.unipept.ugent.be/api/v1/pept2lca</Code>. <RLink to="#parameters" router>Parameters</RLink> can be included in the request body 
+                <Code>https://api.unipept.ugent.be/api/v1/pept2lca</Code>. <RLink to="#parameters" router>Parameters</RLink> can be included in the request body 
                 (<Initialism>POST</Initialism>) or in the query string (<Initialism>GET</Initialism>). The only required parameter is <Code>input[]</Code>, which 
                 takes one or more tryptic peptides.
             </p>
@@ -230,7 +230,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/pept2lca -d 'input[]=AIPQLEVARPADAYETAEAYR'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/pept2lca.json?input[]=AIPQLEVARPADAYETAEAYR
+                https://api.unipept.ugent.be/api/v1/pept2lca.json?input[]=AIPQLEVARPADAYETAEAYR
             </template>
         </ExampleCard>
 
@@ -249,7 +249,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/pept2lca -d 'input[]=AIPQLEVARPADAYETAEAYR' -d 'input[]=APVLSDSSCK'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/pept2lca.json?input[]=AIPQLEVARPADAYETAEAYR&input[]=APVLSDSSCK
+                https://api.unipept.ugent.be/api/v1/pept2lca.json?input[]=AIPQLEVARPADAYETAEAYR&input[]=APVLSDSSCK
             </template>
         </ExampleCard>
 
@@ -266,7 +266,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/pept2lca -d 'input[]=APVISDSSCK' -d 'equate_il=true'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/pept2lca.json?input[]=APVISDSSCK&equate_il=true
+                https://api.unipept.ugent.be/api/v1/pept2lca.json?input[]=APVISDSSCK&equate_il=true
             </template>
         </ExampleCard>
 
@@ -283,7 +283,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/pept2lca -d 'input[]=AIPQLEVARPADAYETAEAYR' -d 'extra=true'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/pept2lca.json?input[]=AIPQLEVARPADAYETAEAYR&extra=true
+                https://api.unipept.ugent.be/api/v1/pept2lca.json?input[]=AIPQLEVARPADAYETAEAYR&extra=true
             </template>
         </ExampleCard>
 
@@ -300,7 +300,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/pept2lca -d 'input[]=AIPQLEVARPADAYETAEAYR' -d 'extra=true' -d 'names=true'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/pept2lca.json?input[]=AIPQLEVARPADAYETAEAYR&extra=true&names=true
+                https://api.unipept.ugent.be/api/v1/pept2lca.json?input[]=AIPQLEVARPADAYETAEAYR&extra=true&names=true
             </template>
         </ExampleCard>
 

--- a/src/components/pages/apidocs/Pept2ProtPage.vue
+++ b/src/components/pages/apidocs/Pept2ProtPage.vue
@@ -16,7 +16,7 @@
         <HeaderBodyCard id="request" title="Request">
             <p>
                 The pept2prot method can be used by doing a <Initialism>HTTP POST</Initialism>-request (preferred) or <Initialism>GET</Initialism>-request to 
-                <Code>http://api.unipept.ugent.be/api/v1/pept2prot</Code>. <RLink to="#parameters" router>Parameters</RLink> can be included in the request body 
+                <Code>https://api.unipept.ugent.be/api/v1/pept2prot</Code>. <RLink to="#parameters" router>Parameters</RLink> can be included in the request body 
                 (<Initialism>POST</Initialism>) or in the query string (<Initialism>GET</Initialism>). The only required parameter is <Code>input[]</Code>, which 
                 takes one or more tryptic peptides.
             </p>
@@ -154,7 +154,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/pept2prot -d 'input[]=AIPQLEVARPADAYETAEAYR'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/pept2prot.json?input[]=AIPQLEVARPADAYETAEAYR
+                https://api.unipept.ugent.be/api/v1/pept2prot.json?input[]=AIPQLEVARPADAYETAEAYR
             </template>
         </ExampleCard>
 
@@ -173,7 +173,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/pept2prot -d 'input[]=AIPQLEVARPADAYETAEAYR' -d 'input[]=APVLSDSSCK'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/pept2prot.json?input[]=AIPQLEVARPADAYETAEAYR&input[]=APVLSDSSCK
+                https://api.unipept.ugent.be/api/v1/pept2prot.json?input[]=AIPQLEVARPADAYETAEAYR&input[]=APVLSDSSCK
             </template>
         </ExampleCard>
 
@@ -190,7 +190,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/pept2prot -d 'input[]=APVISDSSCK' -d 'equate_il=true'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/pept2prot.json?input[]=APVISDSSCK&equate_il=true
+                https://api.unipept.ugent.be/api/v1/pept2prot.json?input[]=APVISDSSCK&equate_il=true
             </template>
         </ExampleCard>
 
@@ -207,7 +207,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/pept2prot -d 'input[]=AIPQLEVARPADAYETAEAYR' -d 'extra=true'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/pept2prot.json?input[]=AIPQLEVARPADAYETAEAYR&extra=true
+                https://api.unipept.ugent.be/api/v1/pept2prot.json?input[]=AIPQLEVARPADAYETAEAYR&extra=true
             </template>
         </ExampleCard>
 

--- a/src/components/pages/apidocs/Pept2TaxaPage.vue
+++ b/src/components/pages/apidocs/Pept2TaxaPage.vue
@@ -16,7 +16,7 @@
         <HeaderBodyCard id="request" title="Request">
             <p>
                 The pept2taxa method can be used by doing a <Initialism>HTTP POST</Initialism>-request (preferred) or <Initialism>GET</Initialism>-request to 
-                <Code>http://api.unipept.ugent.be/api/v1/pept2taxa</Code>. <RLink to="#parameters" router>Parameters</RLink> can be included in the request body 
+                <Code>https://api.unipept.ugent.be/api/v1/pept2taxa</Code>. <RLink to="#parameters" router>Parameters</RLink> can be included in the request body 
                 (<Initialism>POST</Initialism>) or in the query string (<Initialism>GET</Initialism>). The only required parameter is <Code>input[]</Code>, which 
                 takes one or more tryptic peptides.
             </p>
@@ -230,7 +230,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/pept2taxa -d 'input[]=AIPQLEVARPADAYETAEAYR'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/pept2taxa.json?input[]=AIPQLEVARPADAYETAEAYR
+                https://api.unipept.ugent.be/api/v1/pept2taxa.json?input[]=AIPQLEVARPADAYETAEAYR
             </template>
         </ExampleCard>
 
@@ -249,7 +249,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/pept2taxa -d 'input[]=AIPQLEVARPADAYETAEAYR' -d 'input[]=APVLSDSSCK'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/pept2taxa.json?input[]=AIPQLEVARPADAYETAEAYR&input[]=APVLSDSSCK
+                https://api.unipept.ugent.be/api/v1/pept2taxa.json?input[]=AIPQLEVARPADAYETAEAYR&input[]=APVLSDSSCK
             </template>
         </ExampleCard>
 
@@ -267,7 +267,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/pept2taxa -d 'input[]=APVISDSSCK' -d 'equate_il=true'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/pept2taxa.json?input[]=APVISDSSCK&equate_il=true
+                https://api.unipept.ugent.be/api/v1/pept2taxa.json?input[]=APVISDSSCK&equate_il=true
             </template>
         </ExampleCard>
 
@@ -284,7 +284,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/pept2taxa -d 'input[]=AIPQLEVARPADAYETAEAYR' -d 'extra=true'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/pept2taxa.json?input[]=AIPQLEVARPADAYETAEAYR&extra=true
+                https://api.unipept.ugent.be/api/v1/pept2taxa.json?input[]=AIPQLEVARPADAYETAEAYR&extra=true
             </template>
         </ExampleCard>
 
@@ -302,7 +302,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/pept2taxa -d 'input[]=AIPQLEVARPADAYETAEAYR' -d 'extra=true' -d 'names=true'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/pept2taxa.json?input[]=AIPQLEVARPADAYETAEAYR&extra=true&names=true
+                https://api.unipept.ugent.be/api/v1/pept2taxa.json?input[]=AIPQLEVARPADAYETAEAYR&extra=true&names=true
             </template>
         </ExampleCard>
 

--- a/src/components/pages/apidocs/PeptInfoPage.vue
+++ b/src/components/pages/apidocs/PeptInfoPage.vue
@@ -16,7 +16,7 @@
         <HeaderBodyCard id="request" title="Request">
             <p>
                 The peptinfo method can be used by doing a <Initialism>HTTP POST</Initialism>-request (preferred) or <Initialism>GET</Initialism>-request to 
-                <Code>http://api.unipept.ugent.be/api/v1/peptinfo</Code>. <RLink to="#parameters" router>Parameters</RLink> can be included in the request body 
+                <Code>https://api.unipept.ugent.be/api/v1/peptinfo</Code>. <RLink to="#parameters" router>Parameters</RLink> can be included in the request body 
                 (<Initialism>POST</Initialism>) or in the query string (<Initialism>GET</Initialism>). The only required parameter is <Code>input[]</Code>, which 
                 takes one or more tryptic peptides.
             </p>
@@ -247,7 +247,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/peptinfo -d 'input[]=AIPQLEVARPADAYETAEAYR'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/peptinfo.json?input[]=AIPQLEVARPADAYETAEAYR
+                https://api.unipept.ugent.be/api/v1/peptinfo.json?input[]=AIPQLEVARPADAYETAEAYR
             </template>
         </ExampleCard>
 
@@ -266,7 +266,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/peptinfo -d 'input[]=AIPQLEVARPADAYETAEAYR' -d 'input[]=APVLSDSSCK'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/peptinfo.json?input[]=AIPQLEVARPADAYETAEAYR&input[]=APVLSDSSCK
+                https://api.unipept.ugent.be/api/v1/peptinfo.json?input[]=AIPQLEVARPADAYETAEAYR&input[]=APVLSDSSCK
             </template>
         </ExampleCard>
 
@@ -284,7 +284,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/peptinfo -d 'input[]=APVISDSSCK' -d 'equate_il=true'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/peptinfo.json?input[]=APVISDSSCK&equate_il=true
+                https://api.unipept.ugent.be/api/v1/peptinfo.json?input[]=APVISDSSCK&equate_il=true
             </template>
         </ExampleCard>
 
@@ -303,7 +303,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/peptinfo -d 'input[]=AIPQLEVARPADAYETAEAYR' -d 'extra=true'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/peptinfo.json?input[]=AIPQLEVARPADAYETAEAYR&extra=true
+                https://api.unipept.ugent.be/api/v1/peptinfo.json?input[]=AIPQLEVARPADAYETAEAYR&extra=true
             </template>
         </ExampleCard>
 
@@ -321,7 +321,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/peptinfo -d 'input[]=APVLSDSSCK' -d 'domains=true'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/peptinfo.json?input[]=APVLSDSSCK&domains=true
+                https://api.unipept.ugent.be/api/v1/peptinfo.json?input[]=APVLSDSSCK&domains=true
             </template>
         </ExampleCard>
 

--- a/src/components/pages/apidocs/Taxa2LcaPage.vue
+++ b/src/components/pages/apidocs/Taxa2LcaPage.vue
@@ -15,7 +15,7 @@
         <HeaderBodyCard id="request" title="Request">
             <p>
                 The taxa2lca method can be used by doing a <Initialism>HTTP POST</Initialism>-request (preferred) or <Initialism>GET</Initialism>-request to 
-                <Code>http://api.unipept.ugent.be/api/v1/taxa2lca</Code>. <RLink to="#parameters" router>Parameters</RLink> can be included in the request body 
+                <Code>https://api.unipept.ugent.be/api/v1/taxa2lca</Code>. <RLink to="#parameters" router>Parameters</RLink> can be included in the request body 
                 (<Initialism>POST</Initialism>) or in the query string (<Initialism>GET</Initialism>). The only required parameter is <Code>input[]</Code>, which 
                 takes one or more tryptic peptides.
             </p>
@@ -211,7 +211,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/taxa2lca -d 'input[]=817' -d 'input[]=329854' -d 'input[]=1099853'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/taxa2lca.json?input[]=817&input[]=329854&input[]=1099853
+                https://api.unipept.ugent.be/api/v1/taxa2lca.json?input[]=817&input[]=329854&input[]=1099853
             </template>
         </ExampleCard>
 
@@ -231,7 +231,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/taxa2lca -d 'input[]=817' -d 'input[]=329854' -d 'input[]=1099853' -d 'extra=true'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/taxa2lca.json?input[]=817&input[]=329854&input[]=1099853&extra=true
+                https://api.unipept.ugent.be/api/v1/taxa2lca.json?input[]=817&input[]=329854&input[]=1099853&extra=true
             </template>
         </ExampleCard>
 
@@ -251,7 +251,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/taxa2lca -d 'input[]=817' -d 'input[]=329854' -d 'input[]=1099853' -d 'extra=true' -d 'names=true'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/taxa2lca.json?input[]=817&input[]=329854&input[]=1099853&extra=true&names=true
+                https://api.unipept.ugent.be/api/v1/taxa2lca.json?input[]=817&input[]=329854&input[]=1099853&extra=true&names=true
             </template>
         </ExampleCard>
 

--- a/src/components/pages/apidocs/Taxa2TreePage.vue
+++ b/src/components/pages/apidocs/Taxa2TreePage.vue
@@ -15,7 +15,7 @@
         <HeaderBodyCard id="request" title="Request">
             <p>
                 The taxa2tree method can be used by doing a <Initialism>HTTP POST</Initialism>-request (preferred) or <Initialism>GET</Initialism>-request to 
-                <Code>http://api.unipept.ugent.be/api/v1/taxa2tree</Code>. <RLink to="#parameters" router>Parameters</RLink> can be included in the request body 
+                <Code>https://api.unipept.ugent.be/api/v1/taxa2tree</Code>. <RLink to="#parameters" router>Parameters</RLink> can be included in the request body 
                 (<Initialism>POST</Initialism>) or in the query string (<Initialism>GET</Initialism>). The only required parameter is <Code>input[]</Code>, which 
                 takes one or more tryptic peptides.
             </p>
@@ -170,7 +170,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/taxa2tree -d 'input[]=817' -d 'input[]=329854' -d 'input[]=1099853'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/taxa2tree.json?input[]=817&input[]=329854&input[]=1099853
+                https://api.unipept.ugent.be/api/v1/taxa2tree.json?input[]=817&input[]=329854&input[]=1099853
             </template>
         </ExampleCard>
 
@@ -209,7 +209,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/taxa2tree -d 'input[]=817' -d 'input[]=329854' -d 'input[]=1099853' -d 'link=true'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/taxa2tree.json?input[]=817&input[]=329854&input[]=1099853&link=true
+                https://api.unipept.ugent.be/api/v1/taxa2tree.json?input[]=817&input[]=329854&input[]=1099853&link=true
             </template>
         </ExampleCard>
 

--- a/src/components/pages/apidocs/TaxonomyPage.vue
+++ b/src/components/pages/apidocs/TaxonomyPage.vue
@@ -15,7 +15,7 @@
         <HeaderBodyCard id="request" title="Request">
             <p>
                 The taxonomy method can be used by doing a <Initialism>HTTP POST</Initialism>-request (preferred) or <Initialism>GET</Initialism>-request to 
-                <Code>http://api.unipept.ugent.be/api/v1/taxonomy</Code>. <RLink to="#parameters" router>Parameters</RLink> can be included in the request body 
+                <Code>https://api.unipept.ugent.be/api/v1/taxonomy</Code>. <RLink to="#parameters" router>Parameters</RLink> can be included in the request body 
                 (<Initialism>POST</Initialism>) or in the query string (<Initialism>GET</Initialism>). The only required parameter is <Code>input[]</Code>, which 
                 takes one or more tryptic peptides.
             </p>
@@ -207,7 +207,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/taxonomy -d 'input[]=817'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/taxonomy.json?input[]=817
+                https://api.unipept.ugent.be/api/v1/taxonomy.json?input[]=817
             </template>
         </ExampleCard>
 
@@ -226,7 +226,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/taxa2lca -d 'input[]=817' -d 'input[]=329854'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/taxa2lca.json?input[]=817&input[]=329854
+                https://api.unipept.ugent.be/api/v1/taxa2lca.json?input[]=817&input[]=329854
             </template>
         </ExampleCard>
 
@@ -244,7 +244,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/taxonomy -d 'input[]=817' -d 'extra=true'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/taxonomy.json?input[]=817&extra=true
+                https://api.unipept.ugent.be/api/v1/taxonomy.json?input[]=817&extra=true
             </template>
         </ExampleCard>
 
@@ -262,7 +262,7 @@
                 curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v1/taxonomy -d 'input[]=817' -d 'extra=true' -d 'names=true'
             </template>
             <template v-slot:get>
-                http://api.unipept.ugent.be/api/v1/taxonomy.json?input[]=817&extra=true&names=true
+                https://api.unipept.ugent.be/api/v1/taxonomy.json?input[]=817&extra=true&names=true
             </template>
         </ExampleCard>
 
@@ -352,7 +352,7 @@ onBeforeMount(async () => {
     response1.value = await unipeptCommunicator.taxonomy(["817"]);
     response2.value = await unipeptCommunicator.taxonomy(["817", "329854"]);
     response3.value = await unipeptCommunicator.taxonomy(["817"], true, undefined);
-    response3.value = await unipeptCommunicator.taxonomy(["817"], true, true);
+    response4.value = await unipeptCommunicator.taxonomy(["817"], true, true);
 })
 </script>
 

--- a/src/components/pages/clidocs/OverviewPage.vue
+++ b/src/components/pages/clidocs/OverviewPage.vue
@@ -31,7 +31,7 @@
                     </thead>
                     <tbody>
                         <router-link v-for="item in functions" class="clickable" :key="item.resource" :to="item.link" tag="tr">
-                            <td>
+                            <td style="white-space: nowrap;">
                                 <b>{{ item.resource }}</b>
                             </td>
                             <td class="py-3">

--- a/src/components/pages/desktopdocs/DesktopProjectManagementPage.vue
+++ b/src/components/pages/desktopdocs/DesktopProjectManagementPage.vue
@@ -45,7 +45,7 @@
                 </li>
             </ul>
 
-            <h3>Physical representation</h3>
+            <h3 class="mt-3">Physical representation</h3>
             <p>
                 As described above, a single project will correspond to one root folder on your hard drive and will
                 always contain at least the following files and folders:

--- a/src/components/pages/metagenomics/OverviewPage.vue
+++ b/src/components/pages/metagenomics/OverviewPage.vue
@@ -5,7 +5,7 @@
                 Go from a paired-end <Initialism>FASTQ</Initialism> sample to an interactive visualisation in 7 simple commands.
             </p>
 
-            <Boxed class="fs">
+            <Boxed>
                 <Sentinel>$</Sentinel> git clone https://github.com/unipept/umgap.git && cd umgap # download source code
                 <br><Sentinel>$</Sentinel> cargo install --path . # install UMGAP
                 <br><Sentinel>$</Sentinel> git clone https://github.com/unipept/FragGeneScanPlusPlus.git FGSpp # download gene predictor
@@ -32,7 +32,7 @@
             consistent intermediate format, it's easy to plug your own extensions into the pipeline.
         </p>
 
-        <ul class="fs">
+        <ul>
             <li><b><Initialism>UMGAP</Initialism> High Precision</b>: Optimized for high precision identifications on your metagenomics reads.</li>
             <li><b><Initialism>UMGAP</Initialism> Max Precision</b>: Optimized for highest precision, with a small setback on sensitivity.</li>
             <li><b><Initialism>UMGAP</Initialism> Tryptic Precision</b>: Made for fast analyses on your laptop. Fewer results, but accurate.</li>
@@ -287,9 +287,3 @@ const functions = [
     },
 ];
 </script>
-
-<style>
-.fs {
-    font-size: 90%;
-}
-</style>

--- a/src/logic/communicators/unipept/UnipeptCommunicator.ts
+++ b/src/logic/communicators/unipept/UnipeptCommunicator.ts
@@ -1,5 +1,4 @@
-// Should probably be stored in some kind of env
-const base = "http://api.unipept.ugent.be/api/v1/";
+const base = "https://api.unipept.ugent.be/api/v1/";
 
 export default class UnipeptCommunicator {
     public async pept2prot(input: string[], equate_il = false, extra = false): Promise<string[]> {

--- a/src/styles/variables.sass
+++ b/src/styles/variables.sass
@@ -1,3 +1,4 @@
 // This is where all the SASS-variable overrides for Vuetify come. We use the indended syntax here.
 
 $navigation-drawer-border-width: 0px
+$card-text-font-size: 16px


### PR DESCRIPTION
- [x] prevent line breaks in the resources column, one of the calls is now split over 2 lines
<img width="912" alt="Screenshot 2023-01-24 at 22 41 31" src="https://user-images.githubusercontent.com/34175340/214427405-02995052-8ced-45dd-b979-e85eef04b3ee.png">

- [x] Font size is quite small on the docs pages

<img width="1185" alt="Screenshot 2023-01-24 at 22 42 25" src="https://user-images.githubusercontent.com/34175340/214427446-056bdb26-8e17-44a3-baf1-3280a39c7e5e.png">

For now i changed this to 16px.

**Bug fixes**
- [x] The result is empty for me in the examples, but that might be due to the current deployment?
This was my mistake. Base url was http instead of https.

- [x] examples overflow:
I might have fixed this, but this only appears on deployment