### PR TITLE
Fix taxonomic treeview was showing EC-numbers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "unipept-web",
-  "version": "5.0.1",
+  "version": "5.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "unipept-web",
-      "version": "5.0.1",
+      "version": "5.0.5",
       "dependencies": {
         "@vueuse/core": "^9.3.0",
         "core-js": "^3.8.3",
         "pinia": "^2.0.21",
-        "unipept-web-components": "^2.0.2",
+        "unipept-web-components": "^2.0.3",
         "uuid": "^9.0.0",
         "vue": "^2.7.8",
         "vue-router": "^3.5.4",
@@ -12322,9 +12322,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/unipept-web-components": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/unipept-web-components/-/unipept-web-components-2.0.2.tgz",
-      "integrity": "sha512-cy0ZsJ4OUwuKyB3PjknylSA225D9xv2Csa4QsRD6vUerfU7/cFeg+YZUpg1WKrQuwXlyKLgSit2e13qJj8rPug==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/unipept-web-components/-/unipept-web-components-2.0.3.tgz",
+      "integrity": "sha512-D+aeeH1e29h5TlBNbyeDnsimkFiALtL1kKcHyUcfUisbyVLmFxV30P9dQcy2Zko8Mzx9+02I3b410q671Zx4lA==",
       "dependencies": {
         "async": "^3.2.4",
         "canvg": "^4.0.1",
@@ -22689,9 +22689,9 @@
       }
     },
     "unipept-web-components": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/unipept-web-components/-/unipept-web-components-2.0.2.tgz",
-      "integrity": "sha512-cy0ZsJ4OUwuKyB3PjknylSA225D9xv2Csa4QsRD6vUerfU7/cFeg+YZUpg1WKrQuwXlyKLgSit2e13qJj8rPug==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/unipept-web-components/-/unipept-web-components-2.0.3.tgz",
+      "integrity": "sha512-D+aeeH1e29h5TlBNbyeDnsimkFiALtL1kKcHyUcfUisbyVLmFxV30P9dQcy2Zko8Mzx9+02I3b410q671Zx4lA==",
       "requires": {
         "async": "^3.2.4",
         "canvg": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unipept-web",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve --mode development",
@@ -11,7 +11,7 @@
     "@vueuse/core": "^9.3.0",
     "core-js": "^3.8.3",
     "pinia": "^2.0.21",
-    "unipept-web-components": "^2.0.2",
+    "unipept-web-components": "^2.0.3",
     "uuid": "^9.0.0",
     "vue": "^2.7.8",
     "vue-router": "^3.5.4",


### PR DESCRIPTION
This PR provides a fix for an issue where the treeview visualization in the taxonomic summary was showing an EC tree instead of a taxonomic tree.